### PR TITLE
fix build failure after ls updated

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ bin/
 .project
 .settings
 javaConfig.json
+**/.checkstyle

--- a/org.eclipse.jdt.ls.debug/META-INF/MANIFEST.MF
+++ b/org.eclipse.jdt.ls.debug/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Java
 Bundle-SymbolicName: org.eclipse.jdt.ls.debug;singleton:=true
-Bundle-Version: 0.2.0.qualifier
+Bundle-Version: 0.3.0.qualifier
 Bundle-Activator: org.eclipse.jdt.ls.debug.internal.JavaDebuggerServerPlugin
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Import-Package: org.eclipse.jdt.core,

--- a/org.eclipse.jdt.ls.debug/pom.xml
+++ b/org.eclipse.jdt.ls.debug/pom.xml
@@ -5,14 +5,13 @@
     <parent>
         <groupId>org.eclipse.jdt.ls</groupId>
         <artifactId>parent</artifactId>
-        <version>0.2.0-SNAPSHOT</version>
+        <version>0.3.0-SNAPSHOT</version>
     </parent>
     <artifactId>org.eclipse.jdt.ls.debug</artifactId>
     <packaging>eclipse-plugin</packaging>
     <name>${base.name} :: Debug</name>
     <properties>
         <lsp4j.version>0.2.0-SNAPSHOT</lsp4j.version>
-        <checkstyle.config.location>${project.parent.basedir}/google_checks.xml</checkstyle.config.location>
         <checkstyle.skip>false</checkstyle.skip>
     </properties>
     <build>
@@ -67,7 +66,7 @@
                     </dependency>
                 </dependencies>
                 <configuration>
-                    <configLocation>../google_checks.xml</configLocation>
+                    <configLocation>${project.parent.basedir}/google_checks.xml</configLocation>
                     <failOnViolation>true</failOnViolation>
                 </configuration>
             </plugin>


### PR DESCRIPTION
since merged this [commit](https://github.com/vscjavaci/eclipse.jdt.ls/commit/07d9bafd40549952b5b6f6266459ce3aa9d9102b) from eclipse repo, build starts to fail
