### PR TITLE
add command to build the workspace

### DIFF
--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/BuildWorkspaceResult.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/BuildWorkspaceResult.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Red Hat Inc. and others.
+ * Copyright (c) 2017 Microsoft Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/BuildWorkspaceResult.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/BuildWorkspaceResult.java
@@ -1,0 +1,47 @@
+/*******************************************************************************
+ * Copyright (c) 2017 Red Hat Inc. and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Microsoft Corporation. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.jdt.ls.core.internal;
+
+import org.eclipse.lsp4j.jsonrpc.validation.NonNull;
+import org.eclipse.xtext.xbase.lib.Pure;
+
+/**
+ * Representation of a response that server sends to client about the workspace
+ * build result
+ *
+ */
+public class BuildWorkspaceResult {
+
+	@NonNull
+	private BuildWorkspaceStatus status;
+
+	public BuildWorkspaceResult(BuildWorkspaceStatus status) {
+		this.status = status;
+	}
+
+	/**
+	 * @return the status
+	 */
+	@NonNull
+	@Pure
+	public BuildWorkspaceStatus getStatus() {
+		return status;
+	}
+
+	/**
+	 * @param status
+	 *            the status to set
+	 */
+	public void setStatus(BuildWorkspaceStatus status) {
+		this.status = status;
+	}
+
+}

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/BuildWorkspaceStatus.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/BuildWorkspaceStatus.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Red Hat Inc. and others.
+ * Copyright (c) 2017 Microsoft Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -16,5 +16,5 @@ package org.eclipse.jdt.ls.core.internal;
  */
 public enum BuildWorkspaceStatus {
 
-	FAILURE, SUCCESS
+	FAILURE, SUCCESS, CANCELLED
 }

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/BuildWorkspaceStatus.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/BuildWorkspaceStatus.java
@@ -1,0 +1,20 @@
+/*******************************************************************************
+ * Copyright (c) 2017 Red Hat Inc. and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Microsoft Corporation - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.jdt.ls.core.internal;
+
+/**
+ * @author xuzho
+ *
+ */
+public enum BuildWorkspaceStatus {
+
+	FAILURE, SUCCESS
+}

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/JavaProtocolExtensions.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/JavaProtocolExtensions.java
@@ -12,7 +12,6 @@ package org.eclipse.jdt.ls.core.internal;
 
 import java.util.concurrent.CompletableFuture;
 
-import org.eclipse.core.runtime.CoreException;
 import org.eclipse.lsp4j.TextDocumentIdentifier;
 import org.eclipse.lsp4j.jsonrpc.services.JsonNotification;
 import org.eclipse.lsp4j.jsonrpc.services.JsonRequest;
@@ -44,5 +43,5 @@ public interface JavaProtocolExtensions {
 	CompletableFuture<String> resolveClasspaths(ClasspathResolveRequestParams param);
 
 	@JsonRequest
-	CompletableFuture<Object> buildWorkspace(String type) throws CoreException;
+	CompletableFuture<BuildWorkspaceResult> buildWorkspace(String type);
 }

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/JavaProtocolExtensions.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/JavaProtocolExtensions.java
@@ -12,6 +12,7 @@ package org.eclipse.jdt.ls.core.internal;
 
 import java.util.concurrent.CompletableFuture;
 
+import org.eclipse.core.runtime.CoreException;
 import org.eclipse.lsp4j.TextDocumentIdentifier;
 import org.eclipse.lsp4j.jsonrpc.services.JsonNotification;
 import org.eclipse.lsp4j.jsonrpc.services.JsonRequest;
@@ -41,4 +42,7 @@ public interface JavaProtocolExtensions {
 
 	@JsonRequest
 	CompletableFuture<String> resolveClasspaths(ClasspathResolveRequestParams param);
+
+	@JsonRequest
+	CompletableFuture<Object> buildWorkspace(String type) throws CoreException;
 }

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/BuildWorkspaceHandler.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/BuildWorkspaceHandler.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Red Hat Inc. and others.
+ * Copyright (c) 2017 Microsoft Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -11,17 +11,17 @@
 package org.eclipse.jdt.ls.core.internal.handlers;
 
 import static org.eclipse.jdt.ls.core.internal.JavaLanguageServerPlugin.logException;
-import static org.eclipse.lsp4j.jsonrpc.CompletableFutures.computeAsync;
 
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-import java.util.concurrent.CompletableFuture;
 
 import org.eclipse.core.resources.IncrementalProjectBuilder;
 import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.NullProgressMonitor;
+import org.eclipse.core.runtime.OperationCanceledException;
 import org.eclipse.jdt.core.ICompilationUnit;
 import org.eclipse.jdt.core.JavaCore;
 import org.eclipse.jdt.core.compiler.IProblem;
@@ -41,26 +41,26 @@ public class BuildWorkspaceHandler {
 		this.sharedASTProvider = SharedASTProvider.getInstance();
 	}
 
-	public CompletableFuture<BuildWorkspaceResult> buildWorkspace() {
-		return computeAsync((cc) -> {
-			try {
-				ResourcesPlugin.getWorkspace().build(IncrementalProjectBuilder.INCREMENTAL_BUILD, new NullProgressMonitor());
-				List<IProblem> errors = getBuildErrors();
-				if (errors.isEmpty()) {
-					return new BuildWorkspaceResult(BuildWorkspaceStatus.SUCCESS);
-				} else {
-					return new BuildWorkspaceResult(BuildWorkspaceStatus.FAILURE);
-				}
-			} catch (CoreException e) {
-				logException("Failed to build workspace.", e);
+	public BuildWorkspaceResult buildWorkspace(IProgressMonitor monitor) {
+		try {
+			ResourcesPlugin.getWorkspace().build(IncrementalProjectBuilder.INCREMENTAL_BUILD, monitor);
+			List<IProblem> errors = getBuildErrors();
+			if (errors.isEmpty()) {
+				return new BuildWorkspaceResult(BuildWorkspaceStatus.SUCCESS);
+			} else {
 				return new BuildWorkspaceResult(BuildWorkspaceStatus.FAILURE);
 			}
-		});
+		} catch (CoreException e) {
+			logException("Failed to build workspace.", e);
+			return new BuildWorkspaceResult(BuildWorkspaceStatus.FAILURE);
+		} catch (OperationCanceledException e) {
+			return new BuildWorkspaceResult(BuildWorkspaceStatus.CANCELLED);
+		}
 	}
 
 	private List<IProblem> getBuildErrors() {
 		this.sharedASTProvider.invalidateAll();
-		ArrayList<IProblem> errors = new ArrayList<>();
+		List<IProblem> errors = new ArrayList<>();
 		List<ICompilationUnit> toValidate = Arrays.asList(JavaCore.getWorkingCopies(null));
 		List<CompilationUnit> astRoots = this.sharedASTProvider.getASTs(toValidate, new NullProgressMonitor());
 		for (CompilationUnit astRoot : astRoots) {

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/BuildWorkspaceHandler.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/BuildWorkspaceHandler.java
@@ -1,0 +1,75 @@
+/*******************************************************************************
+ * Copyright (c) 2017 Red Hat Inc. and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Microsoft Corporation - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.jdt.ls.core.internal.handlers;
+
+import static org.eclipse.jdt.ls.core.internal.JavaLanguageServerPlugin.logException;
+import static org.eclipse.lsp4j.jsonrpc.CompletableFutures.computeAsync;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+
+import org.eclipse.core.resources.IncrementalProjectBuilder;
+import org.eclipse.core.resources.ResourcesPlugin;
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.NullProgressMonitor;
+import org.eclipse.jdt.core.ICompilationUnit;
+import org.eclipse.jdt.core.JavaCore;
+import org.eclipse.jdt.core.compiler.IProblem;
+import org.eclipse.jdt.core.dom.CompilationUnit;
+import org.eclipse.jdt.ls.core.internal.BuildWorkspaceResult;
+import org.eclipse.jdt.ls.core.internal.BuildWorkspaceStatus;
+import org.eclipse.jdt.ls.core.internal.SharedASTProvider;
+
+/**
+ * @author xuzho
+ *
+ */
+public class BuildWorkspaceHandler {
+	private SharedASTProvider sharedASTProvider;
+
+	public BuildWorkspaceHandler() {
+		this.sharedASTProvider = SharedASTProvider.getInstance();
+	}
+
+	public CompletableFuture<BuildWorkspaceResult> buildWorkspace() {
+		return computeAsync((cc) -> {
+			try {
+				ResourcesPlugin.getWorkspace().build(IncrementalProjectBuilder.INCREMENTAL_BUILD, new NullProgressMonitor());
+				List<IProblem> errors = getBuildErrors();
+				if (errors.isEmpty()) {
+					return new BuildWorkspaceResult(BuildWorkspaceStatus.SUCCESS);
+				} else {
+					return new BuildWorkspaceResult(BuildWorkspaceStatus.FAILURE);
+				}
+			} catch (CoreException e) {
+				logException("Failed to build workspace.", e);
+				return new BuildWorkspaceResult(BuildWorkspaceStatus.FAILURE);
+			}
+		});
+	}
+
+	private List<IProblem> getBuildErrors() {
+		this.sharedASTProvider.invalidateAll();
+		ArrayList<IProblem> errors = new ArrayList<>();
+		List<ICompilationUnit> toValidate = Arrays.asList(JavaCore.getWorkingCopies(null));
+		List<CompilationUnit> astRoots = this.sharedASTProvider.getASTs(toValidate, new NullProgressMonitor());
+		for (CompilationUnit astRoot : astRoots) {
+			for (IProblem problem : astRoot.getProblems()) {
+				if (problem.isError()) {
+					errors.add(problem);
+				}
+			}
+		}
+		return errors;
+	}
+}

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/JDTLanguageServer.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/JDTLanguageServer.java
@@ -22,7 +22,11 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 
+import org.eclipse.core.resources.IncrementalProjectBuilder;
+import org.eclipse.core.resources.ResourcesPlugin;
+import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.core.runtime.NullProgressMonitor;
 import org.eclipse.core.runtime.OperationCanceledException;
 import org.eclipse.core.runtime.jobs.Job;
 import org.eclipse.jdt.core.WorkingCopyOwner;
@@ -461,6 +465,16 @@ public class JDTLanguageServer implements LanguageServer, TextDocumentService, W
 		logInfo(">> java/resolveClasspath");
 		ResolveClasspathsHandler handler = new ResolveClasspathsHandler();
 		return handler.resolveClasspaths(param);
+	}
+
+	/* (non-Javadoc)
+	 * @see org.eclipse.jdt.ls.core.internal.JavaProtocolExtensions#buildWorkspace(java.lang.String)
+	 */
+	@Override
+	public CompletableFuture<Object> buildWorkspace(String type) throws CoreException {
+		logInfo(">> java/buildWorkspace");
+		ResourcesPlugin.getWorkspace().build(IncrementalProjectBuilder.INCREMENTAL_BUILD, new NullProgressMonitor());
+		return CompletableFuture.completedFuture(new Object());
 	}
 
 	public void sendStatus(ServiceStatus serverStatus, String status) {

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/JDTLanguageServer.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/JDTLanguageServer.java
@@ -22,14 +22,11 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 
-import org.eclipse.core.resources.IncrementalProjectBuilder;
-import org.eclipse.core.resources.ResourcesPlugin;
-import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IProgressMonitor;
-import org.eclipse.core.runtime.NullProgressMonitor;
 import org.eclipse.core.runtime.OperationCanceledException;
 import org.eclipse.core.runtime.jobs.Job;
 import org.eclipse.jdt.core.WorkingCopyOwner;
+import org.eclipse.jdt.ls.core.internal.BuildWorkspaceResult;
 import org.eclipse.jdt.ls.core.internal.CancellableProgressMonitor;
 import org.eclipse.jdt.ls.core.internal.ClasspathResolveRequestParams;
 import org.eclipse.jdt.ls.core.internal.JavaClientConnection;
@@ -471,10 +468,9 @@ public class JDTLanguageServer implements LanguageServer, TextDocumentService, W
 	 * @see org.eclipse.jdt.ls.core.internal.JavaProtocolExtensions#buildWorkspace(java.lang.String)
 	 */
 	@Override
-	public CompletableFuture<Object> buildWorkspace(String type) throws CoreException {
+	public CompletableFuture<BuildWorkspaceResult> buildWorkspace(String type) {
 		logInfo(">> java/buildWorkspace");
-		ResourcesPlugin.getWorkspace().build(IncrementalProjectBuilder.INCREMENTAL_BUILD, new NullProgressMonitor());
-		return CompletableFuture.completedFuture(new Object());
+		return new BuildWorkspaceHandler().buildWorkspace();
 	}
 
 	public void sendStatus(ServiceStatus serverStatus, String status) {

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/JDTLanguageServer.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/JDTLanguageServer.java
@@ -470,7 +470,8 @@ public class JDTLanguageServer implements LanguageServer, TextDocumentService, W
 	@Override
 	public CompletableFuture<BuildWorkspaceResult> buildWorkspace(String type) {
 		logInfo(">> java/buildWorkspace");
-		return new BuildWorkspaceHandler().buildWorkspace();
+		BuildWorkspaceHandler handler = new BuildWorkspaceHandler();
+		return computeAsync((cc) -> handler.buildWorkspace(toMonitor(cc)));
 	}
 
 	public void sendStatus(ServiceStatus serverStatus, String status) {


### PR DESCRIPTION
Signed-off-by: xuzho <xuzho@microsoft.com>

we need this for single file debug as if you
 1. open a java file from vscode, 
 2. don't do any change, 
 3. hit debug button
then debugger cannot be launched successfully as the default project which links to the file isn't built yet and bin folder doesn't contain .class file