### PR TITLE
fix exceptionbreakpoint bug: vm wouldn't disconnect after resuming an exception breakpoint

### DIFF
--- a/org.eclipse.jdt.ls.debug/src/org/eclipse/jdt/ls/debug/internal/DebugSession.java
+++ b/org.eclipse.jdt.ls.debug/src/org/eclipse/jdt/ls/debug/internal/DebugSession.java
@@ -84,6 +84,7 @@ public class DebugSession implements IDebugSession {
         ArrayList<ExceptionRequest> legacy = new ArrayList<ExceptionRequest>(manager.exceptionRequests());
         manager.deleteEventRequests(legacy);
         ExceptionRequest request = manager.createExceptionRequest(null, notifyCaught, notifyUncaught);
+        request.setSuspendPolicy(EventRequest.SUSPEND_EVENT_THREAD);
         request.enable();
     }
 


### PR DESCRIPTION
the default behavior is `SUSPEND_ALL` but our code only resume the thread that suspend at the breakpoint. fix it.

Signed-off-by: xuzho <xuzho@microsoft.com>